### PR TITLE
feat: add clean URL for Clawdio @ BNB privacy policy

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -45,7 +45,9 @@ export default siteConfig({
   //   '/foo': '067dd719a912471ea9a3ac10710e7fdf',
   //   '/bar': '0be6efce9daf42688f65c76b89f8eb27'
   // }
-  pageUrlOverrides: null,
+  pageUrlOverrides: {
+    '/privacy/clawdio-bnb': '30af7adc634a81048376fdd6a72ac5a2'
+  },
 
   // whether to use the default notion navigation style or a custom one with links to
   // important pages


### PR DESCRIPTION
Adds a pageUrlOverrides entry mapping `/privacy/clawdio-bnb` to the Notion privacy policy page for the Clawdio @ BNB Meta App.

Once merged: https://abd.dev/privacy/clawdio-bnb