### PR TITLE
seo: improve meta description and add structured data

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -21,7 +21,13 @@ export function PageHead({
 }) {
   const rssFeedUrl = `${config.host}/feed`
 
+  const isHomePage = url === config.host || url === `${config.host}/`
+
   title = title ?? site?.name
+  // Use a keyword-rich title for the homepage
+  if (isHomePage && title === site?.name) {
+    title = `${site?.name} — Engineering, AI Systems & Agentic Development`
+  }
   description = description ?? site?.description
 
   const socialImageUrl = getSocialImageUrl(pageId) || image
@@ -102,7 +108,49 @@ export function PageHead({
       <meta name='twitter:title' content={title} />
       <title>{title}</title>
 
-      {/* Better SEO for the blog posts */}
+      {/* Person + WebSite schema for homepage */}
+      {isHomePage && (
+        <script type='application/ld+json'>
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@graph': [
+              {
+                '@type': 'Person',
+                '@id': `${config.host}/#person`,
+                name: config.author,
+                url: config.host,
+                jobTitle: 'Founder & CTO',
+                worksFor: {
+                  '@type': 'Organization',
+                  name: 'Autonomous',
+                  url: 'https://autonomoustech.ca'
+                },
+                sameAs: [
+                  config.twitter
+                    ? `https://twitter.com/${config.twitter}`
+                    : null,
+                  config.github
+                    ? `https://github.com/${config.github}`
+                    : null,
+                  config.linkedin
+                    ? `https://linkedin.com/in/${config.linkedin}`
+                    : null
+                ].filter(Boolean)
+              },
+              {
+                '@type': 'WebSite',
+                '@id': `${config.host}/#website`,
+                url: config.host,
+                name: site?.name,
+                description: site?.description,
+                author: { '@id': `${config.host}/#person` }
+              }
+            ]
+          })}
+        </script>
+      )}
+
+      {/* Article schema for blog posts */}
       {isBlogPost && (
         <script type='application/ld+json'>
           {JSON.stringify({
@@ -116,7 +164,15 @@ export function PageHead({
             description,
             author: {
               '@type': 'Person',
-              name: config.author
+              '@id': `${config.host}/#person`,
+              name: config.author,
+              url: config.host
+            },
+            publisher: {
+              '@type': 'Person',
+              '@id': `${config.host}/#person`,
+              name: config.author,
+              url: config.host
             },
             image: socialImageUrl
           })}

--- a/site.config.ts
+++ b/site.config.ts
@@ -14,7 +14,8 @@ export default siteConfig({
   author: 'Abdullah Abid',
 
   // open graph metadata (optional)
-  description: 'Personal site of Abdullah Abid',
+  description:
+    'Abdullah Abid writes about software engineering, AI agents, and building with LLMs. Founder at Autonomous. Practical insights from real-world agentic systems.',
 
   // social usernames (optional)
   twitter: 'mabdullahabid_',


### PR DESCRIPTION
## Summary

SEO improvements based on a full audit of abd.dev.

### Changes

**`site.config.ts`**
- Updated `description` from `'Personal site of Abdullah Abid'` (31 chars, no keywords) to a keyword-rich value prop (157 chars)

**`components/PageHead.tsx`**
- Homepage title now appends `— Engineering, AI Systems & Agentic Development` for keyword coverage
- Added `Person` + `WebSite` JSON-LD schema on homepage for AI search entity recognition
- Enhanced `BlogPosting` schema with `publisher` field linked to the Person entity

### Why

The audit flagged these as highest-impact:
- Title was 13 chars with zero keywords
- Meta description was 31 chars with no value prop
- Zero structured data = invisible to AI Overviews, ChatGPT, Perplexity
- Blog posts had no publisher linkage to the author entity

### Validation

Schema can be validated at https://validator.schema.org/ after deploy.